### PR TITLE
Use a URL-safe alphabet and strip/pad trailing equal signs to ensure compat with other B64 encoders

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,16 +8,16 @@ class TestDeckFMT(unittest.TestCase):
         self.decklist_files = [
             (
                 "list_1offs.txt",
-                "ECAU2RjKFlBScpaUlWVLJFkwysZc0wLFzMh2NTYZw0+GfIEXS4ZWtOmYNMRmyzgp6N+mcjOU",
+                "ECAU2RjKFlBScpaUlWVLJFkwysZc0wLFzMh2NTYZw0-GfIEXS4ZWtOmYNMRmyzgp6N-mcjOU",
             ),
-            ("list_2sets.txt", "ECAjGhnSHpR0s6gdRaqPWRrRVp64deQESnV0UqcdPA=="),
+            ("list_2sets.txt", "ECAjGhnSHpR0s6gdRaqPWRrRVp64deQESnV0UqcdPA"),
             (
                 "list_uniques.txt",
-                "EBAVnBjhHww4lcSeILFNjDx5S+so2TPLDRcOHGX4iUOcWt1XazI5t8wW8g==",
+                "EBAVnBjhHww4lcSeILFNjDx5S-so2TPLDRcOHGX4iUOcWt1XazI5t8wW8g",
             ),
-            ("list_yzmir.txt", "EBAk3hnUK4h8daVOIvjFyx5h846zfTGuXmb6p9YuwPaHsgA="),
+            ("list_yzmir.txt", "EBAk3hnUK4h8daVOIvjFyx5h846zfTGuXmb6p9YuwPaHsgA"),
             ("test_extd_qty.txt", "EBAgTTMo"),
-            ("test_long_uniq.txt", "EBARGz4JpNnycPbPmBy2f//8"),
+            ("test_long_uniq.txt", "EBARGz4JpNnycPbPmBy2f__8"),
             ("test_mana_orb.txt", "EBAg3hHfC8IA"),
         ]
 


### PR DESCRIPTION
Matches encoding from: https://github.com/Taum/altered-deckfmt/commit/45fc605bf6212f2578cbeb7dc6be59b19f80d9e0

I realized tonight that we were using the default Base64 alphabet which is not URL safe. Given the context in which we plan to use this encoding, it seemed like a major oversight. I moved to the URL-safe alphabet (a.k.a. `base64url`, see [RFC-4648 section 5](https://datatracker.ietf.org/doc/html/rfc4648#section-5)) which should be implemented by most major libraries.

I noticed the default JS implementation of `base64url` strips trailing `=` signs, so I took the liberty to match this here since it was fairly trivial to implement. We can make this mandatory in the spec to ensure other readers also support it.